### PR TITLE
Parametrize Promise with implementing class and update Open methods to stop spans from activating

### DIFF
--- a/trace-util/src/main/java/com/feedzai/commons/tracing/util/LazyConfigTracer.java
+++ b/trace-util/src/main/java/com/feedzai/commons/tracing/util/LazyConfigTracer.java
@@ -138,7 +138,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                 final String description) {
         return getEngine().addToTraceOpenPromise(toTraceAsync, object, description);
     }
@@ -160,7 +160,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                 final String description, final String eventId) {
         return getEngine().addToTraceOpenPromise(toTraceAsync, object, description, eventId);
     }
@@ -190,7 +190,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                 final String description, final TraceContext context) {
         return this.getEngine().addToTraceOpenPromise(toTraceAsync, object, description, context);
     }
@@ -225,7 +225,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
                                             final TraceContext context) {
         return this.getEngine().newProcessPromise(toTrace, description, context);
     }
@@ -253,7 +253,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
                                             final TraceContext context) {
         return this.getEngine().addToTracePromise(toTraceAsync, description, context);
     }
@@ -294,7 +294,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description) {
         return this.getEngine().newTracePromise(toTraceAsync, description);
     }
 
@@ -314,7 +314,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description) {
         return this.getEngine().addToTracePromise(toTraceAsync, description);
     }
 
@@ -340,7 +340,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description, final String eventId) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description, final String eventId) {
         return this.getEngine().newTracePromise(toTraceAsync, description, eventId);
     }
 
@@ -361,7 +361,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
                                             final String eventId) {
         return this.getEngine().newProcessPromise(toTrace, description, eventId);
     }
@@ -383,7 +383,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description, final String eventId) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description, final String eventId) {
         return this.getEngine().addToTracePromise(toTraceAsync, description, eventId);
     }
 

--- a/trace-util/src/main/java/com/feedzai/commons/tracing/util/LazyConfigTracer.java
+++ b/trace-util/src/main/java/com/feedzai/commons/tracing/util/LazyConfigTracer.java
@@ -138,7 +138,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                 final String description) {
         return getEngine().addToTraceOpenPromise(toTraceAsync, object, description);
     }
@@ -160,7 +160,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                 final String description, final String eventId) {
         return getEngine().addToTraceOpenPromise(toTraceAsync, object, description, eventId);
     }
@@ -190,7 +190,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                 final String description, final TraceContext context) {
         return this.getEngine().addToTraceOpenPromise(toTraceAsync, object, description, context);
     }
@@ -225,7 +225,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
+    public <P extends Promise<R,P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
                                             final TraceContext context) {
         return this.getEngine().newProcessPromise(toTrace, description, context);
     }
@@ -253,7 +253,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
+    public <P extends Promise<R,P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
                                             final TraceContext context) {
         return this.getEngine().addToTracePromise(toTraceAsync, description, context);
     }
@@ -294,7 +294,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description) {
+    public <P extends Promise<R,P>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description) {
         return this.getEngine().newTracePromise(toTraceAsync, description);
     }
 
@@ -314,7 +314,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description) {
+    public <P extends Promise<R,P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description) {
         return this.getEngine().addToTracePromise(toTraceAsync, description);
     }
 
@@ -340,7 +340,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description, final String eventId) {
+    public <P extends Promise<R,P>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description, final String eventId) {
         return this.getEngine().newTracePromise(toTraceAsync, description, eventId);
     }
 
@@ -361,7 +361,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
+    public <P extends Promise<R,P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
                                             final String eventId) {
         return this.getEngine().newProcessPromise(toTrace, description, eventId);
     }
@@ -383,7 +383,7 @@ public class LazyConfigTracer implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description, final String eventId) {
+    public <P extends Promise<R,P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description, final String eventId) {
         return this.getEngine().addToTracePromise(toTraceAsync, description, eventId);
     }
 

--- a/trace-util/src/main/java/com/feedzai/commons/tracing/util/TraceUtil.java
+++ b/trace-util/src/main/java/com/feedzai/commons/tracing/util/TraceUtil.java
@@ -15,6 +15,7 @@
  */
 
 package com.feedzai.commons.tracing.util;
+import com.feedzai.commons.tracing.engine.NoopTracingEngine;
 import com.feedzai.commons.tracing.engine.TracingEngine;
 
 /**
@@ -28,7 +29,7 @@ public class TraceUtil {
     /**
      * The tracer engine.
      */
-    private static volatile TracingEngine engine;
+    private static volatile TracingEngine engine = new NoopTracingEngine();
 
     private TraceUtil(){}
 

--- a/trace-util/src/main/java/com/feedzai/commons/tracing/util/configuration/TracingConfiguration.java
+++ b/trace-util/src/main/java/com/feedzai/commons/tracing/util/configuration/TracingConfiguration.java
@@ -36,4 +36,11 @@ public class TracingConfiguration {
      */
     public JaegerConfiguration jaegerConfiguration;
 
+    @Override
+    public String toString() {
+        return "TracingConfiguration{" +
+                "activeEngine=" + activeEngine +
+                ", jaegerConfiguration=" + jaegerConfiguration +
+                '}';
+    }
 }

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/Promise.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/Promise.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
  * @param <T> The type consumed by the onComplete method.
  * @author Gonçalo Garcia (goncalo.garcia@feedzai.com)
  */
-public interface Promise<T> {
+public interface Promise<T, P extends Promise<T, P>> {
 
 
     /**
@@ -33,7 +33,7 @@ public interface Promise<T> {
      * @param callOnCompletion Lambda that represents the method that should be executed upon completion
      * @return This {@link Promise}
      */
-    <P extends Promise<R>, R> P onCompletePromise(Consumer<T> callOnCompletion);
+    P onCompletePromise(Consumer<T> callOnCompletion);
 
     /**
      * Registers a method to be called by the {@link Promise} when the result of the computation terminates with an
@@ -43,7 +43,7 @@ public interface Promise<T> {
      *                    implementing {@link Promise}
      * @return This {@link Promise}
      */
-    <P extends Promise<R>, R> P onErrorPromise(Consumer<Throwable> callOnError);
+    P onErrorPromise(Consumer<Throwable> callOnError);
 
 
 

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/Promise.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/Promise.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
  * @param <T> The type consumed by the onComplete method.
  * @author Gonçalo Garcia (goncalo.garcia@feedzai.com)
  */
-public interface Promise<T, P extends Promise<T, P>> {
+public interface Promise<T, P extends Promise<T, P, E>, E extends Throwable> {
 
 
     /**
@@ -43,7 +43,7 @@ public interface Promise<T, P extends Promise<T, P>> {
      *                    implementing {@link Promise}
      * @return This {@link Promise}
      */
-    P onErrorPromise(Consumer<Throwable> callOnError);
+    P onErrorPromise(Consumer<E> callOnError);
 
 
 

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/Tracing.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/Tracing.java
@@ -83,7 +83,7 @@ public interface Tracing {
      * @param <P>          The class implementing {@link Promise}
      * @return Returns the {@link Promise} the traced code would've returned.
      */
-    <P extends Promise<R>, R> P newTracePromise(Supplier<P> toTraceAsync, String description);
+    <P extends Promise<R,P>, R> P newTracePromise(Supplier<P> toTraceAsync, String description);
 
     /**
      * Traces operations that return a value of any type. This method will add a Span to an existing trace which will
@@ -137,7 +137,7 @@ public interface Tracing {
      * @param <P>          The class implementing {@link Promise}
      * @return Returns the {@link Promise} the traced code would've returned.
      */
-    <P extends Promise<R>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description);
+    <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description);
 
     /**
      * Returns whether or not there is a currently active span.

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/Tracing.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/Tracing.java
@@ -83,7 +83,7 @@ public interface Tracing {
      * @param <P>          The class implementing {@link Promise}
      * @return Returns the {@link Promise} the traced code would've returned.
      */
-    <P extends Promise<R,P>, R> P newTracePromise(Supplier<P> toTraceAsync, String description);
+    <E extends Throwable, P extends Promise<R, P, E>, R> P newTracePromise(Supplier<P> toTraceAsync, String description);
 
     /**
      * Traces operations that return a value of any type. This method will add a Span to an existing trace which will
@@ -137,7 +137,7 @@ public interface Tracing {
      * @param <P>          The class implementing {@link Promise}
      * @return Returns the {@link Promise} the traced code would've returned.
      */
-    <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description);
+    <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description);
 
     /**
      * Returns whether or not there is a currently active span.

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingOpen.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingOpen.java
@@ -43,7 +43,7 @@ public interface TracingOpen extends Tracing {
      *                     it is time to finish it.
      * @return What was to be returned by the traced code.
      */
-    <P extends Promise<R>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    <P extends Promise<R, P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                       final String description);
 
     /**

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingOpen.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingOpen.java
@@ -43,7 +43,7 @@ public interface TracingOpen extends Tracing {
      *                     it is time to finish it.
      * @return What was to be returned by the traced code.
      */
-    <P extends Promise<R, P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                       final String description);
 
     /**

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingOpenWithContext.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingOpenWithContext.java
@@ -49,7 +49,7 @@ public interface TracingOpenWithContext extends TracingWithContext {
      * @param context      Represents the context of the current execution.
      * @return What was to be returned by the traced code.
      */
-    <P extends Promise<R>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                       final String description,
                                       final TraceContext context);
 

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingOpenWithContext.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingOpenWithContext.java
@@ -49,7 +49,7 @@ public interface TracingOpenWithContext extends TracingWithContext {
      * @param context      Represents the context of the current execution.
      * @return What was to be returned by the traced code.
      */
-    <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                       final String description,
                                       final TraceContext context);
 

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingOpenWithId.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingOpenWithId.java
@@ -47,7 +47,7 @@ public interface TracingOpenWithId extends TracingWithId {
      * @param <P>          The class implementing {@link Promise}
      * @return What was to be returned by the traced code.
      */
-    <P extends Promise<R>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                       final String description,
                                       final String eventId);
 

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingOpenWithId.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingOpenWithId.java
@@ -47,7 +47,7 @@ public interface TracingOpenWithId extends TracingWithId {
      * @param <P>          The class implementing {@link Promise}
      * @return What was to be returned by the traced code.
      */
-    <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                       final String description,
                                       final String eventId);
 

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingWithContext.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingWithContext.java
@@ -76,7 +76,7 @@ public interface TracingWithContext extends Tracing {
      * @param <P>          The class implementing {@link Promise}
      * @return The instrumented Promise.
      */
-    <P extends Promise<R>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
+    <P extends Promise<R, P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
                                      final TraceContext context);
 
     /**
@@ -159,7 +159,7 @@ public interface TracingWithContext extends Tracing {
      * @param <P>          The class implementing {@link Promise}
      * @return Returns the {@link Promise} the traced code would've returned.
      */
-    <P extends Promise<R>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, TraceContext context);
+    <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, TraceContext context);
 
 
     /**

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingWithContext.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingWithContext.java
@@ -76,7 +76,7 @@ public interface TracingWithContext extends Tracing {
      * @param <P>          The class implementing {@link Promise}
      * @return The instrumented Promise.
      */
-    <P extends Promise<R, P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
+    <E extends Throwable, P extends Promise<R, P, E>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
                                      final TraceContext context);
 
     /**
@@ -159,7 +159,7 @@ public interface TracingWithContext extends Tracing {
      * @param <P>          The class implementing {@link Promise}
      * @return Returns the {@link Promise} the traced code would've returned.
      */
-    <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, TraceContext context);
+    <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, TraceContext context);
 
 
     /**

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingWithId.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingWithId.java
@@ -90,7 +90,7 @@ public interface TracingWithId {
      * @param <P>          The class implementing {@link Promise}
      * @return Returns the {@link Promise} the traced code would've returned.
      */
-    <P extends Promise<R,P>, R> P newTracePromise(Supplier<P> toTraceAsync, String description, String eventId);
+    <E extends Throwable, P extends Promise<R, P, E>, R> P newTracePromise(Supplier<P> toTraceAsync, String description, String eventId);
 
     /**
      * Creates a new Span that is the root of this process's portion of the trace. Similarly to {@link
@@ -153,7 +153,7 @@ public interface TracingWithId {
      * @param <P>          The class implementing {@link Promise}
      * @return What was to be returned by the traced code.
      */
-    <P extends Promise<R,P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description, final String eventId);
+    <E extends Throwable, P extends Promise<R, P, E>, R> P newProcessPromise(final Supplier<P> toTrace, final String description, final String eventId);
 
     /**
      * Traces operations that return a value of any type. This method will add a Span to an existing trace which will
@@ -215,7 +215,7 @@ public interface TracingWithId {
      * @param <P>          The class implementing {@link Promise}
      * @return Returns the {@link Promise} the traced code would've returned.
      */
-    <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, String eventId);
+    <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, String eventId);
 
 
 

--- a/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingWithId.java
+++ b/tracing-api/src/main/java/com/feedzai/commons/tracing/api/TracingWithId.java
@@ -90,7 +90,7 @@ public interface TracingWithId {
      * @param <P>          The class implementing {@link Promise}
      * @return Returns the {@link Promise} the traced code would've returned.
      */
-    <P extends Promise<R>, R> P newTracePromise(Supplier<P> toTraceAsync, String description, String eventId);
+    <P extends Promise<R,P>, R> P newTracePromise(Supplier<P> toTraceAsync, String description, String eventId);
 
     /**
      * Creates a new Span that is the root of this process's portion of the trace. Similarly to {@link
@@ -153,7 +153,7 @@ public interface TracingWithId {
      * @param <P>          The class implementing {@link Promise}
      * @return What was to be returned by the traced code.
      */
-    <P extends Promise<R>, R> P newProcessPromise(final Supplier<P> toTrace, final String description, final String eventId);
+    <P extends Promise<R,P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description, final String eventId);
 
     /**
      * Traces operations that return a value of any type. This method will add a Span to an existing trace which will
@@ -215,7 +215,7 @@ public interface TracingWithId {
      * @param <P>          The class implementing {@link Promise}
      * @return Returns the {@link Promise} the traced code would've returned.
      */
-    <P extends Promise<R>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, String eventId);
+    <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, String eventId);
 
 
 

--- a/tracing-lib-jaeger/src/main/java/com/feedzai/commons/tracing/engine/configuration/JaegerConfiguration.java
+++ b/tracing-lib-jaeger/src/main/java/com/feedzai/commons/tracing/engine/configuration/JaegerConfiguration.java
@@ -48,4 +48,14 @@ public class JaegerConfiguration {
      */
     public String ip;
 
+    @Override
+    public String toString() {
+        return "JaegerConfiguration{" +
+                "cacheDurationInMinutes=" + cacheDurationInMinutes +
+                ", cacheMaxSize=" + cacheMaxSize +
+                ", sampleRate=" + sampleRate +
+                ", processName='" + processName + '\'' +
+                ", ip='" + ip + '\'' +
+                '}';
+    }
 }

--- a/tracing-lib-logger/src/main/java/com/feedzai/commons/tracing/engine/LoggingTracingEngine.java
+++ b/tracing-lib-logger/src/main/java/com/feedzai/commons/tracing/engine/LoggingTracingEngine.java
@@ -56,7 +56,7 @@ public class LoggingTracingEngine implements TracingEngine {
 
 
     @Override
-    public <P extends Promise<R>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                 final String description) {
         return logPromise(toTraceAsync, description, Optional.empty());
 
@@ -89,7 +89,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                 final String description, final String eventId) {
         return logPromise(toTraceAsync, description, Optional.empty());
     }
@@ -125,7 +125,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                 final String description, final TraceContext context) {
         return logPromise(toTraceAsync, description, Optional.empty());
     }
@@ -172,7 +172,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
+    public <P extends Promise<R,P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
                                             final TraceContext context) {
         return logPromise(toTrace, description, Optional.empty());
     }
@@ -210,7 +210,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
+    public <P extends Promise<R,P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
                                             final TraceContext context) {
         return logPromise(toTraceAsync, description, Optional.empty());
     }
@@ -257,7 +257,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description) {
+    public <P extends Promise<R,P>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description) {
         return logPromise(toTraceAsync, description, Optional.empty());
     }
 
@@ -283,7 +283,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description) {
+    public <P extends Promise<R,P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description) {
         return logPromise(toTraceAsync, description, Optional.empty());
 
     }
@@ -316,7 +316,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description,
+    public <P extends Promise<R,P>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description,
                                           final String eventId) {
         return logPromise(toTraceAsync, description, Optional.of(eventId));
 
@@ -345,7 +345,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
+    public <P extends Promise<R,P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
                                             final String eventId) {
         return logPromise(toTrace, description, Optional.of(eventId));
     }
@@ -379,7 +379,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
+    public <P extends Promise<R,P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
                                             final String eventId) {
         return logPromise(toTraceAsync, description, Optional.of(eventId));
     }
@@ -391,9 +391,9 @@ public class LoggingTracingEngine implements TracingEngine {
      * @param <R> The return type.
      * @return Whatever would be returned by the Promise.
      */
-    private <P extends Promise<R>, R> P logPromise(Supplier<P> toTraceAsync, String description, Optional<String> eventId) {
+    private <P extends Promise<R,P>, R> P logPromise(Supplier<P> toTraceAsync, String description, Optional<String> eventId) {
         final double start = System.nanoTime();
-        final Promise<R> promise = toTraceAsync.get();
+        final P promise = toTraceAsync.get();
         promise.onErrorPromise(throwable -> logMessage(description, start, eventId));
         promise.onCompletePromise(throwable -> logMessage(description, start, eventId));
         return toTraceAsync.get();

--- a/tracing-lib-logger/src/main/java/com/feedzai/commons/tracing/engine/LoggingTracingEngine.java
+++ b/tracing-lib-logger/src/main/java/com/feedzai/commons/tracing/engine/LoggingTracingEngine.java
@@ -56,7 +56,7 @@ public class LoggingTracingEngine implements TracingEngine {
 
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                 final String description) {
         return logPromise(toTraceAsync, description, Optional.empty());
 
@@ -89,7 +89,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                 final String description, final String eventId) {
         return logPromise(toTraceAsync, description, Optional.empty());
     }
@@ -125,7 +125,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                 final String description, final TraceContext context) {
         return logPromise(toTraceAsync, description, Optional.empty());
     }
@@ -172,7 +172,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
                                             final TraceContext context) {
         return logPromise(toTrace, description, Optional.empty());
     }
@@ -210,7 +210,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
                                             final TraceContext context) {
         return logPromise(toTraceAsync, description, Optional.empty());
     }
@@ -257,7 +257,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description) {
         return logPromise(toTraceAsync, description, Optional.empty());
     }
 
@@ -283,7 +283,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description) {
         return logPromise(toTraceAsync, description, Optional.empty());
 
     }
@@ -316,7 +316,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description,
                                           final String eventId) {
         return logPromise(toTraceAsync, description, Optional.of(eventId));
 
@@ -345,7 +345,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
                                             final String eventId) {
         return logPromise(toTrace, description, Optional.of(eventId));
     }
@@ -379,7 +379,7 @@ public class LoggingTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
                                             final String eventId) {
         return logPromise(toTraceAsync, description, Optional.of(eventId));
     }
@@ -391,7 +391,7 @@ public class LoggingTracingEngine implements TracingEngine {
      * @param <R> The return type.
      * @return Whatever would be returned by the Promise.
      */
-    private <P extends Promise<R,P>, R> P logPromise(Supplier<P> toTraceAsync, String description, Optional<String> eventId) {
+    private <E extends Throwable, P extends Promise<R, P, E>, R> P logPromise(Supplier<P> toTraceAsync, String description, Optional<String> eventId) {
         final double start = System.nanoTime();
         final P promise = toTraceAsync.get();
         promise.onErrorPromise(throwable -> logMessage(description, start, eventId));

--- a/tracing-lib-noop/src/main/java/com/feedzai/commons/tracing/engine/NoopTracingEngine.java
+++ b/tracing-lib-noop/src/main/java/com/feedzai/commons/tracing/engine/NoopTracingEngine.java
@@ -47,7 +47,7 @@ public class NoopTracingEngine implements TracingEngine {
     };
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
                                                 String description) {
         return toTraceAsync.get();
     }
@@ -69,7 +69,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
                                                 String description, String eventId) {
         return toTraceAsync.get();
     }
@@ -100,7 +100,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
                                                 String description, TraceContext context) {
         return toTraceAsync.get();
     }
@@ -137,7 +137,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newProcessPromise(Supplier<P> toTrace, String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newProcessPromise(Supplier<P> toTrace, String description,
                                             TraceContext context) {
         return toTrace.get();
     }
@@ -166,7 +166,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description,
                                             TraceContext context) {
         return toTraceAsync.get();
     }
@@ -207,7 +207,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newTracePromise(Supplier<P> toTraceAsync, String description) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newTracePromise(Supplier<P> toTraceAsync, String description) {
         return toTraceAsync.get();
     }
 
@@ -228,7 +228,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description) {
         return toTraceAsync.get();
     }
 
@@ -255,7 +255,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
         return toTraceAsync.get();
     }
 
@@ -277,7 +277,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newProcessPromise(Supplier<P> toTrace, String description, String eventId) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newProcessPromise(Supplier<P> toTrace, String description, String eventId) {
         return toTrace.get();
     }
 
@@ -299,7 +299,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
         return toTraceAsync.get();
     }
 

--- a/tracing-lib-noop/src/main/java/com/feedzai/commons/tracing/engine/NoopTracingEngine.java
+++ b/tracing-lib-noop/src/main/java/com/feedzai/commons/tracing/engine/NoopTracingEngine.java
@@ -47,7 +47,7 @@ public class NoopTracingEngine implements TracingEngine {
     };
 
     @Override
-    public <P extends Promise<R>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
+    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
                                                 String description) {
         return toTraceAsync.get();
     }
@@ -69,7 +69,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
+    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
                                                 String description, String eventId) {
         return toTraceAsync.get();
     }
@@ -100,7 +100,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
+    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
                                                 String description, TraceContext context) {
         return toTraceAsync.get();
     }
@@ -137,7 +137,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newProcessPromise(Supplier<P> toTrace, String description,
+    public <P extends Promise<R,P>, R> P newProcessPromise(Supplier<P> toTrace, String description,
                                             TraceContext context) {
         return toTrace.get();
     }
@@ -166,7 +166,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description,
+    public <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description,
                                             TraceContext context) {
         return toTraceAsync.get();
     }
@@ -207,7 +207,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newTracePromise(Supplier<P> toTraceAsync, String description) {
+    public <P extends Promise<R,P>, R> P newTracePromise(Supplier<P> toTraceAsync, String description) {
         return toTraceAsync.get();
     }
 
@@ -228,7 +228,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description) {
+    public <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description) {
         return toTraceAsync.get();
     }
 
@@ -255,7 +255,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
+    public <P extends Promise<R,P>, R> P newTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
         return toTraceAsync.get();
     }
 
@@ -277,7 +277,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newProcessPromise(Supplier<P> toTrace, String description, String eventId) {
+    public <P extends Promise<R,P>, R> P newProcessPromise(Supplier<P> toTrace, String description, String eventId) {
         return toTrace.get();
     }
 
@@ -299,7 +299,7 @@ public class NoopTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
+    public <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
         return toTraceAsync.get();
     }
 

--- a/tracing-lib/src/main/java/com/feedzai/commons/tracing/engine/AbstractOpenTracingEngine.java
+++ b/tracing-lib/src/main/java/com/feedzai/commons/tracing/engine/AbstractOpenTracingEngine.java
@@ -99,7 +99,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R, P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
                                                             final TraceContext context) {
         final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context, true);
         spanIdMappings.put(getTraceIdFromSpan(span), new LinkedList<>());
@@ -119,7 +119,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R, P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                                 final String description,
                                                                 final TraceContext context) {
         final Span span = buildSpanAsChild(description, (SpanTraceContext) context);
@@ -128,7 +128,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R, P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                                 final String description) {
         final Span span = buildSpan(description);
         responseMappings.put(object, span);
@@ -212,7 +212,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
 
 
     @Override
-    public <P extends Promise<R, P>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description) {
         final Span span = buildActiveParentSpan(description);
         return finishParentPromiseSpan(toTraceAsync, span);
     }
@@ -260,14 +260,14 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R, P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description) {
         final Span span = buildActiveSpan(description);
         return finishPromiseSpan(toTraceAsync, span);
     }
 
 
     @Override
-    public <P extends Promise<R, P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
                                                             final TraceContext context) {
         final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context, true);
         return finishPromiseSpan(toTraceAsync, span);
@@ -339,7 +339,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
      * @param span         The span that is wrapping the execution and should be finished.
      * @return the same {@link Promise} that was passed in {@code toTraceAsync}
      */
-    <P extends Promise<R, P>, R> P finishPromiseSpan(final Supplier<P> toTraceAsync, final Span span) {
+    <E extends Throwable, P extends Promise<R, P, E>, R> P finishPromiseSpan(final Supplier<P> toTraceAsync, final Span span) {
         return toTraceAsync.get().onCompletePromise(x -> {
             finishActive(span);
             popSpanForTraceId(span);
@@ -359,7 +359,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
      * @param span         The span that is wrapping the execution and should be finished.
      * @return the same {@link Promise} that was passed in {@code toTraceAsync}
      */
-    <P extends Promise<R, P>, R> P finishParentPromiseSpan(final Supplier<P> toTraceAsync, final Span span) {
+    <E extends Throwable, P extends Promise<R, P, E>, R> P finishParentPromiseSpan(final Supplier<P> toTraceAsync, final Span span) {
         return toTraceAsync.get().onCompletePromise(x -> {
             span.finish();
         }).onErrorPromise(x -> {

--- a/tracing-lib/src/main/java/com/feedzai/commons/tracing/engine/AbstractOpenTracingEngine.java
+++ b/tracing-lib/src/main/java/com/feedzai/commons/tracing/engine/AbstractOpenTracingEngine.java
@@ -58,8 +58,6 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     protected final Cache<Object, Span> responseMappings;
 
 
-
-
     /**
      * The logger.
      */
@@ -82,7 +80,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
 
     @Override
     public <R> R newProcess(final Supplier<R> toTrace, final String description, final TraceContext context) {
-        final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context);
+        final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context, true);
         spanIdMappings.put(getTraceIdFromSpan(span), new LinkedList<>());
         updateSpanMappings(span);
 
@@ -93,7 +91,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
 
     @Override
     public void newProcess(final Runnable toTrace, final String description, final TraceContext context) {
-        final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context);
+        final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context, true);
         spanIdMappings.put(getTraceIdFromSpan(span), new LinkedList<>());
         updateSpanMappings(span);
 
@@ -101,9 +99,9 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
-                                  final TraceContext context) {
-        final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context);
+    public <P extends Promise<R, P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
+                                                            final TraceContext context) {
+        final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context, true);
         spanIdMappings.put(getTraceIdFromSpan(span), new LinkedList<>());
         updateSpanMappings(span);
 
@@ -111,27 +109,28 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     }
 
     @Override
-    public <R> CompletableFuture<R> newProcessFuture(final Supplier<CompletableFuture<R>> toTrace, final String description,
-                                 final TraceContext context) {
-        final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context);
+    public <R> CompletableFuture<R> newProcessFuture(final Supplier<CompletableFuture<R>> toTrace,
+                                                     final String description,
+                                                     final TraceContext context) {
+        final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context, true);
         spanIdMappings.put(getTraceIdFromSpan(span), new LinkedList<>());
         updateSpanMappings(span);
         return finishParentFutureSpan(toTrace.get(), span);
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
-                                             final String description,
-                                             final TraceContext context) {
-        final Span span = buildActiveSpanAsChild(description, (SpanTraceContext) context);
+    public <P extends Promise<R, P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+                                                                final String description,
+                                                                final TraceContext context) {
+        final Span span = buildSpanAsChild(description, (SpanTraceContext) context);
         responseMappings.put(object, span);
         return toTraceAsync.get();
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
-                                             final String description) {
-        final Span span = buildActiveSpan(description);
+    public <P extends Promise<R, P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+                                                                final String description) {
+        final Span span = buildSpan(description);
         responseMappings.put(object, span);
         return toTraceAsync.get();
     }
@@ -141,7 +140,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
                                                          final Object object,
                                                          final String description,
                                                          final TraceContext context) {
-        final Span span = buildActiveSpanAsChild(description, (SpanTraceContext) context);
+        final Span span = buildSpanAsChild(description, (SpanTraceContext) context);
         responseMappings.put(object, span);
         return toTraceAsync.get();
     }
@@ -150,7 +149,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     public <R> CompletableFuture<R> addToTraceOpenFuture(final Supplier<CompletableFuture<R>> toTraceAsync,
                                                          final Object object,
                                                          final String description) {
-        final Span span = buildActiveSpan(description);
+        final Span span = buildSpan(description);
         responseMappings.put(object, span);
         return toTraceAsync.get();
     }
@@ -158,7 +157,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     @Override
     public void addToTraceOpen(final Runnable toTraceAsync, final Object object, final String description,
                                final TraceContext context) {
-        final Span span = buildActiveSpanAsChild(description, (SpanTraceContext) context);
+        final Span span = buildSpanAsChild(description, (SpanTraceContext) context);
         final String traceId = getTraceIdFromSpan(span);
         cacheObject(object, span, traceId);
         toTraceAsync.run();
@@ -167,7 +166,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     @Override
     public <R> R addToTraceOpen(final Supplier<R> toTraceAsync, final Object value, final String description,
                                 final TraceContext context) {
-        final Span span = buildActiveSpanAsChild(description, (SpanTraceContext) context);
+        final Span span = buildSpanAsChild(description, (SpanTraceContext) context);
         final String traceId = getTraceIdFromSpan(span);
         cacheObject(value, span, traceId);
         return toTraceAsync.get();
@@ -175,7 +174,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
 
     @Override
     public void addToTraceOpen(final Runnable toTrace, final Object object, final String description) {
-        final Span span = buildActiveSpan(description);
+        final Span span = buildSpan(description);
         final String traceId = getTraceIdFromSpan(span);
         cacheObject(object, span, traceId);
         toTrace.run();
@@ -183,7 +182,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
 
     @Override
     public <R> R addToTraceOpen(final Supplier<R> toTrace, final Object value, final String description) {
-        final Span span = buildActiveSpan(description);
+        final Span span = buildSpan(description);
         final String traceId = getTraceIdFromSpan(span);
         cacheObject(value, span, traceId);
         return toTrace.get();
@@ -213,7 +212,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
 
 
     @Override
-    public <P extends Promise<R>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description) {
+    public <P extends Promise<R, P>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description) {
         final Span span = buildActiveParentSpan(description);
         return finishParentPromiseSpan(toTraceAsync, span);
     }
@@ -256,21 +255,21 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     @Override
     public <R> CompletableFuture<R> addToTraceAsync(final Supplier<CompletableFuture<R>> toTraceAsync,
                                                     final String description, final TraceContext context) {
-        final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context);
+        final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context, true);
         return finishFutureSpan(toTraceAsync.get(), span);
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description) {
+    public <P extends Promise<R, P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description) {
         final Span span = buildActiveSpan(description);
         return finishPromiseSpan(toTraceAsync, span);
     }
 
 
     @Override
-    public <P extends Promise<R>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
-                                     final TraceContext context) {
-        final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context);
+    public <P extends Promise<R, P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
+                                                            final TraceContext context) {
+        final Span span = buildSpanFromAsyncContext(description, (SpanTraceContext) context, true);
         return finishPromiseSpan(toTraceAsync, span);
     }
 
@@ -287,7 +286,8 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     /**
      * Finishes span after the {@link CompletableFuture} has completed, either successfully or exceptionally.
      *
-     * <p>Similar to {@link AbstractOpenTracingEngine#finishPromiseSpan(Supplier, Span)} but for {@link CompletableFuture}
+     * <p>Similar to {@link AbstractOpenTracingEngine#finishPromiseSpan(Supplier, Span)} but for {@link
+     * CompletableFuture}
      *
      * @param toTraceAsync The {@link CompletableFuture} to which the callback will be attached.
      * @param span         The span that is wrapping the execution and should be finished.
@@ -296,9 +296,8 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
      */
     <R> CompletableFuture<R> finishFutureSpan(final CompletableFuture<R> toTraceAsync, final Span span) {
         toTraceAsync.handle((future, exception) -> {
-            span.finish();
+            finishActive(span);
             popSpanForTraceId(span);
-            tracer.scopeManager().active().close();
             return future;
         });
         return toTraceAsync;
@@ -314,7 +313,8 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     /**
      * Finishes span after the {@link CompletableFuture} has completed, either successfully or exceptionally.
      *
-     * <p>Similar to {@link AbstractOpenTracingEngine#finishPromiseSpan(Supplier, Span)} but for {@link CompletableFuture}
+     * <p>Similar to {@link AbstractOpenTracingEngine#finishPromiseSpan(Supplier, Span)} but for {@link
+     * CompletableFuture}
      *
      * @param toTraceAsync The {@link CompletableFuture} to which the callback will be attached.
      * @param span         The span that is wrapping the execution and should be finished.
@@ -323,8 +323,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
      */
     <R> CompletableFuture<R> finishParentFutureSpan(final CompletableFuture<R> toTraceAsync, final Span span) {
         toTraceAsync.handle((future, exception) -> {
-            span.finish();
-            tracer.scopeManager().active().close();
+            finishActive(span);
             return future;
         });
         return toTraceAsync;
@@ -333,18 +332,19 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     /**
      * Attaches callback to finish span after the {@link Promise} has completed.
      *
-     * <p>Similar to {@link AbstractOpenTracingEngine#finishFutureSpan(CompletableFuture, Span)} but for {@link Promise}
+     * <p>Similar to {@link AbstractOpenTracingEngine#finishFutureSpan(CompletableFuture, Span)} but for {@link
+     * Promise}
      *
      * @param toTraceAsync The {@link Promise} to which the callback will be attached.
      * @param span         The span that is wrapping the execution and should be finished.
      * @return the same {@link Promise} that was passed in {@code toTraceAsync}
      */
-    <P extends Promise<R>, R> P finishPromiseSpan(final Supplier<P> toTraceAsync, final Span span) {
+    <P extends Promise<R, P>, R> P finishPromiseSpan(final Supplier<P> toTraceAsync, final Span span) {
         return toTraceAsync.get().onCompletePromise(x -> {
-            span.finish();
+            finishActive(span);
             popSpanForTraceId(span);
         }).onErrorPromise(x -> {
-            span.finish();
+            finishActive(span);
             popSpanForTraceId(span);
         });
     }
@@ -352,13 +352,14 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     /**
      * Attaches callback to finish span after the {@link Promise} has completed.
      *
-     * <p>Similar to {@link AbstractOpenTracingEngine#finishFutureSpan(CompletableFuture, Span)} but for {@link Promise}
+     * <p>Similar to {@link AbstractOpenTracingEngine#finishFutureSpan(CompletableFuture, Span)} but for {@link
+     * Promise}
      *
      * @param toTraceAsync The {@link Promise} to which the callback will be attached.
      * @param span         The span that is wrapping the execution and should be finished.
      * @return the same {@link Promise} that was passed in {@code toTraceAsync}
      */
-    <P extends Promise<R>, R> P finishParentPromiseSpan(final Supplier<P> toTraceAsync, final Span span) {
+    <P extends Promise<R, P>, R> P finishParentPromiseSpan(final Supplier<P> toTraceAsync, final Span span) {
         return toTraceAsync.get().onCompletePromise(x -> {
             span.finish();
         }).onErrorPromise(x -> {
@@ -382,7 +383,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
         try {
             result = toTrace.get();
         } finally {
-            span.finish();
+            finishActive(span);
             popSpanForTraceId(span);
         }
         return result;
@@ -422,7 +423,7 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
         try {
             toTrace.run();
         } finally {
-            span.finish();
+            finishActive(span);
             popSpanForTraceId(span);
         }
     }
@@ -452,10 +453,13 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
      * @param context     Represents the context of the current execution.
      * @return The new active Span.
      */
-    private Span buildSpanFromAsyncContext(final String description, final SpanTraceContext context) {
+    private Span buildSpanFromAsyncContext(final String description, final SpanTraceContext context,
+                                           final boolean activate) {
         final Span span = this.tracer.buildSpan(description).ignoreActiveSpan().asChildOf(context != null ? context.get() : null).start();
         span.setBaggageItem("thread-id", Long.toString(Thread.currentThread().getId()));
-        this.tracer.scopeManager().activate(span, true);
+        if (activate) {
+            this.tracer.scopeManager().activate(span, true);
+        }
         updateSpanMappings(span);
         return span;
     }
@@ -503,14 +507,30 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     }
 
     /**
-     * Creates a new Span that is a child of the passed {@link SpanTraceContext}.
+     * Creates a new Span that is a child of the passed {@link SpanTraceContext}, but does not activate it in the
+     * current thread.
+     *
+     * @param description The description or name that best describes this operation.
+     * @param context     The parent of this new span.
+     * @return the new child Span.
+     */
+    Span buildSpanAsChild(final String description, final SpanTraceContext context) {
+        final Span span = buildSpanFromAsyncContext(description, context, false);
+        span.setBaggageItem("thread-id", Long.toString(Thread.currentThread().getId()));
+        updateSpanMappings(span);
+        return span;
+    }
+
+    /**
+     * Creates a new Span that is a child of the passed {@link SpanTraceContext} and activates it in the current
+     * thread.
      *
      * @param description The description or name that best describes this operation.
      * @param context     The parent of this new span.
      * @return the new child Span.
      */
     Span buildActiveSpanAsChild(final String description, final SpanTraceContext context) {
-        final Span span = buildSpanFromAsyncContext(description, context);
+        final Span span = buildSpanFromAsyncContext(description, context, true);
         span.setBaggageItem("thread-id", Long.toString(Thread.currentThread().getId()));
         this.tracer.scopeManager().activate(span, true);
         updateSpanMappings(span);
@@ -532,6 +552,20 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
     }
 
     /**
+     * Builds a span but does not activate it.
+     *
+     * @param description The description or name that best describes this operation.
+     * @return the new active span.
+     */
+    private Span buildSpan(final String description) {
+        final Span span = this.tracer.buildSpan(description).start();
+        span.setBaggageItem("thread-id", Long.toString(Thread.currentThread().getId()));
+        this.tracer.scopeManager().activate(span, false);
+        updateSpanMappings(span);
+        return span;
+    }
+
+    /**
      * Stores this object in the {@code responseMappings} cache and updates {@code spanMappings} since it might span
      * multiple threads.
      *
@@ -546,6 +580,19 @@ public abstract class AbstractOpenTracingEngine implements TracingEngine {
         responseMappings.put(object, span);
     }
 
+
+    /**
+     * Finishes a Span that is active and deactivates it.
+     *
+     * @param span The span to be finished.
+     */
+    private void finishActive(Span span) {
+        if (tracer.activeSpan() != null && tracer.activeSpan().equals(span)) {
+            tracer.scopeManager().active().close();
+        } else {
+            span.finish();
+        }
+    }
 
 
     @Override

--- a/tracing-lib/src/main/java/com/feedzai/commons/tracing/engine/AbstractOpenTracingEngineWithId.java
+++ b/tracing-lib/src/main/java/com/feedzai/commons/tracing/engine/AbstractOpenTracingEngineWithId.java
@@ -83,7 +83,7 @@ public abstract class AbstractOpenTracingEngineWithId extends AbstractOpenTracin
     }
 
     @Override
-    public <P extends Promise<R, P>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newTracePromise(final Supplier<P> toTraceAsync, final String description,
                                                           final String eventId) {
         final Span span = newTraceWithId(description, eventId);
         return finishParentPromiseSpan(toTraceAsync, span);
@@ -109,7 +109,7 @@ public abstract class AbstractOpenTracingEngineWithId extends AbstractOpenTracin
     }
 
     @Override
-    public <P extends Promise<R, P>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(final Supplier<P> toTraceAsync, final String description,
                                                             final String eventId) {
         final Span span = buildActiveContextFromId(description, eventId);
 
@@ -147,7 +147,7 @@ public abstract class AbstractOpenTracingEngineWithId extends AbstractOpenTracin
     }
 
     @Override
-    public <P extends Promise<R, P>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newProcessPromise(final Supplier<P> toTrace, final String description,
                                                             final String eventId) {
         final Span span = buildActiveContextFromId(description, eventId);
         spanIdMappings.put(getTraceIdFromSpan(span), new LinkedList<>());
@@ -156,7 +156,7 @@ public abstract class AbstractOpenTracingEngineWithId extends AbstractOpenTracin
     }
 
     @Override
-    public <P extends Promise<R, P>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(final Supplier<P> toTraceAsync, final Object object,
                                                                 final String description,
                                                                 final String eventId) {
         final Span span = buildContextFromId(description, eventId);

--- a/tracing-lib/src/test/java/com/feedzai/commons/tracing/engine/MockPromise.java
+++ b/tracing-lib/src/test/java/com/feedzai/commons/tracing/engine/MockPromise.java
@@ -20,7 +20,7 @@ import com.feedzai.commons.tracing.api.Promise;
 
 import java.util.function.Consumer;
 
-public class MockPromise implements Promise<String> {
+public class MockPromise implements Promise<String, MockPromise> {
 
     Consumer callOnCompletion;
     Consumer callOnError;
@@ -32,14 +32,14 @@ public class MockPromise implements Promise<String> {
     }
 
     @Override
-    public <P extends Promise<R>, R> P onCompletePromise(Consumer<String> callOnCompletion) {
+    public MockPromise onCompletePromise(Consumer<String> callOnCompletion) {
         this.callOnCompletion = callOnCompletion;
-        return (P) this;
+        return this;
     }
 
     @Override
-    public <P extends Promise<R>, R> P onErrorPromise(Consumer<Throwable> callOnError) {
+    public MockPromise onErrorPromise(Consumer<Throwable> callOnError) {
         this.callOnError = callOnError;
-        return (P) this;
+        return this;
     }
 }

--- a/tracing-lib/src/test/java/com/feedzai/commons/tracing/engine/MockPromise.java
+++ b/tracing-lib/src/test/java/com/feedzai/commons/tracing/engine/MockPromise.java
@@ -20,7 +20,7 @@ import com.feedzai.commons.tracing.api.Promise;
 
 import java.util.function.Consumer;
 
-public class MockPromise implements Promise<String, MockPromise> {
+public class MockPromise implements Promise<String, MockPromise, Throwable> {
 
     Consumer callOnCompletion;
     Consumer callOnError;

--- a/tracing-lib/src/test/java/com/feedzai/commons/tracing/engine/MockTracingEngine.java
+++ b/tracing-lib/src/test/java/com/feedzai/commons/tracing/engine/MockTracingEngine.java
@@ -47,7 +47,7 @@ public class MockTracingEngine extends AbstractOpenTracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
                                              String description, String eventId) {
         return null;
     }
@@ -100,7 +100,7 @@ public class MockTracingEngine extends AbstractOpenTracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
         return null;
     }
 
@@ -121,7 +121,7 @@ public class MockTracingEngine extends AbstractOpenTracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P newProcessPromise(Supplier<P> toTrace, String description, String eventId) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P newProcessPromise(Supplier<P> toTrace, String description, String eventId) {
         return null;
     }
 
@@ -142,7 +142,7 @@ public class MockTracingEngine extends AbstractOpenTracingEngine {
     }
 
     @Override
-    public <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
+    public <E extends Throwable, P extends Promise<R, P, E>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
         return null;
     }
 

--- a/tracing-lib/src/test/java/com/feedzai/commons/tracing/engine/MockTracingEngine.java
+++ b/tracing-lib/src/test/java/com/feedzai/commons/tracing/engine/MockTracingEngine.java
@@ -47,7 +47,7 @@ public class MockTracingEngine extends AbstractOpenTracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
+    public <P extends Promise<R,P>, R> P addToTraceOpenPromise(Supplier<P> toTraceAsync, Object object,
                                              String description, String eventId) {
         return null;
     }
@@ -100,7 +100,7 @@ public class MockTracingEngine extends AbstractOpenTracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
+    public <P extends Promise<R,P>, R> P newTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
         return null;
     }
 
@@ -121,7 +121,7 @@ public class MockTracingEngine extends AbstractOpenTracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P newProcessPromise(Supplier<P> toTrace, String description, String eventId) {
+    public <P extends Promise<R,P>, R> P newProcessPromise(Supplier<P> toTrace, String description, String eventId) {
         return null;
     }
 
@@ -142,7 +142,7 @@ public class MockTracingEngine extends AbstractOpenTracingEngine {
     }
 
     @Override
-    public <P extends Promise<R>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
+    public <P extends Promise<R,P>, R> P addToTracePromise(Supplier<P> toTraceAsync, String description, String eventId) {
         return null;
     }
 


### PR DESCRIPTION
The parametrization of the Promise class with the class/interface that is implementing/extending it allows implementing classes to parametrize the Consumer passed as argument instead of depending on the generic type T.

The Open methods are changed to stop them from activating spans as it does not make sense for a span that represents some idle execution to be activated in the current thread.