### PR TITLE
Exclude non-shaded jaeger-thrift dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,12 @@
                 <groupId>io.jaegertracing</groupId>
                 <artifactId>jaeger-client</artifactId>
                 <version>${jaeger.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.jaegertracing</groupId>
+                        <artifactId>jaeger-thrift</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.opentracing</groupId>

--- a/tracing-lib-jaeger/pom.xml
+++ b/tracing-lib-jaeger/pom.xml
@@ -46,6 +46,12 @@
         <dependency>
             <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.jaegertracing</groupId>
+                    <artifactId>jaeger-thrift</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.feedzai.commons.tracing</groupId>

--- a/tracing-lib-jaeger/pom.xml
+++ b/tracing-lib-jaeger/pom.xml
@@ -46,12 +46,6 @@
         <dependency>
             <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-client</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.jaegertracing</groupId>
-                    <artifactId>jaeger-thrift</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.feedzai.commons.tracing</groupId>


### PR DESCRIPTION
The non shaded version of this dependency pulls the apache thrift client
as a transitive dependency which results in conflicts in systems that
also depend on the thrift client.