### PR TITLE
Remove usages of GlobalTracer from JaegerTracingEngine

### DIFF
--- a/tracing-lib-jaeger/src/main/java/com/feedzai/commons/tracing/engine/JaegerTracingEngine.java
+++ b/tracing-lib-jaeger/src/main/java/com/feedzai/commons/tracing/engine/JaegerTracingEngine.java
@@ -121,8 +121,8 @@ public class JaegerTracingEngine extends AbstractOpenTracingEngineWithId {
      */
     public Map<String, String> serializeContextForId(final String id) {
         final HashMap<String, String> map = new HashMap<>();
-        if (GlobalTracer.isRegistered() && traceIdMappings.getIfPresent(id) != null) {
-            GlobalTracer.get().inject(
+        if (traceIdMappings.getIfPresent(id) != null && spanIdMappings.getIfPresent(traceIdMappings.getIfPresent(id)).peek() != null) {
+            tracer.inject(
                     spanIdMappings.getIfPresent(traceIdMappings.getIfPresent(id)).peek().context(),
                     Format.Builtin.TEXT_MAP, implementTextMap(map));
         }


### PR DESCRIPTION
Since we're no longer registering with GlobalTracer, using it to check
that the tracer has been initialized produces incorrect behavior.